### PR TITLE
Add Nendoroid Viewer project skeleton

### DIFF
--- a/nendoroid_viewer/README.md
+++ b/nendoroid_viewer/README.md
@@ -1,0 +1,11 @@
+# Nendoroid Viewer
+
+This project aggregates data about Nendoroid figures and provides a web interface for browsing them.
+
+Directories:
+
+- `scraper/` – Python scraper that collects data from the official website.
+- `backend/` – FastAPI application exposing an API backed by a PostgreSQL database.
+- `frontend/` – Vue 3 + Vite web application.
+
+Each directory contains a README with setup instructions.

--- a/nendoroid_viewer/README.md
+++ b/nendoroid_viewer/README.md
@@ -2,6 +2,8 @@
 
 This project aggregates data about Nendoroid figures and provides a web interface for browsing them.
 
+The database stores each figure's name, description, announcement and release dates as well as all image URLs scraped from the official site.
+
 Directories:
 
 - `scraper/` – Python scraper that collects data from the official website.

--- a/nendoroid_viewer/backend/README.md
+++ b/nendoroid_viewer/backend/README.md
@@ -2,6 +2,8 @@
 
 This is the FastAPI backend for the Nendoroid Viewer project.
 
+The API exposes `/nendoroids`, returning figures with name, description, announcement and release dates and image URLs.
+
 ## Setup
 
 1. Create a virtual environment and install dependencies:

--- a/nendoroid_viewer/backend/README.md
+++ b/nendoroid_viewer/backend/README.md
@@ -1,0 +1,22 @@
+# Nendoroid Viewer Backend
+
+This is the FastAPI backend for the Nendoroid Viewer project.
+
+## Setup
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Set the `DATABASE_URL` environment variable if necessary. The default is:
+`postgresql+asyncpg://user:password@localhost/nendoroids`
+
+3. Run the API:
+
+```bash
+uvicorn app.main:app --reload
+```

--- a/nendoroid_viewer/backend/app/database.py
+++ b/nendoroid_viewer/backend/app/database.py
@@ -1,0 +1,13 @@
+import os
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://user:password@localhost/nendoroids")
+
+engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+
+async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+async def get_session() -> AsyncSession:
+    async with async_session() as session:
+        yield session

--- a/nendoroid_viewer/backend/app/main.py
+++ b/nendoroid_viewer/backend/app/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from .database import get_session
+from .models import Base, Nendoroid
+
+app = FastAPI(title="Nendoroid Viewer API")
+
+@app.on_event("startup")
+async def on_startup():
+    # create tables if they don't exist
+    async with get_session() as session:
+        await session.run_sync(Base.metadata.create_all)
+
+@app.get("/nendoroids")
+async def list_nendoroids(fandom: str | None = None, season: str | None = None, session: AsyncSession = Depends(get_session)):
+    query = select(Nendoroid)
+    if fandom:
+        query = query.where(Nendoroid.fandom == fandom)
+    if season:
+        query = query.where(Nendoroid.season == season)
+    result = await session.execute(query)
+    return [n._asdict() if hasattr(n, '_asdict') else {
+        'id': n.id, 'product_id': n.product_id, 'name': n.name,
+        'fandom': n.fandom, 'season': n.season, 'release_date': n.release_date
+    } for n in result.scalars().all()]

--- a/nendoroid_viewer/backend/app/main.py
+++ b/nendoroid_viewer/backend/app/main.py
@@ -20,7 +20,18 @@ async def list_nendoroids(fandom: str | None = None, season: str | None = None, 
     if season:
         query = query.where(Nendoroid.season == season)
     result = await session.execute(query)
-    return [n._asdict() if hasattr(n, '_asdict') else {
-        'id': n.id, 'product_id': n.product_id, 'name': n.name,
-        'fandom': n.fandom, 'season': n.season, 'release_date': n.release_date
-    } for n in result.scalars().all()]
+    return [
+        {
+            'id': n.id,
+            'product_id': n.product_id,
+            'name': n.name,
+            'description': n.description,
+            'announcement_date': n.announcement_date,
+            'release_date': n.release_date,
+            'fandom': n.fandom,
+            'season': n.season,
+            'images': n.images,
+            'product_url': n.product_url,
+        }
+        for n in result.scalars().all()
+    ]

--- a/nendoroid_viewer/backend/app/models.py
+++ b/nendoroid_viewer/backend/app/models.py
@@ -1,0 +1,14 @@
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, Integer, String, Date
+
+Base = declarative_base()
+
+class Nendoroid(Base):
+    __tablename__ = 'nendoroids'
+
+    id = Column(Integer, primary_key=True)
+    product_id = Column(String, unique=True, nullable=False)
+    name = Column(String, nullable=False)
+    fandom = Column(String)
+    season = Column(String)
+    release_date = Column(Date)

--- a/nendoroid_viewer/backend/app/models.py
+++ b/nendoroid_viewer/backend/app/models.py
@@ -1,5 +1,6 @@
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String, Date
+from sqlalchemy import Column, Integer, String, Date, Text
+from sqlalchemy.dialects.postgresql import JSONB
 
 Base = declarative_base()
 
@@ -9,6 +10,10 @@ class Nendoroid(Base):
     id = Column(Integer, primary_key=True)
     product_id = Column(String, unique=True, nullable=False)
     name = Column(String, nullable=False)
+    description = Column(Text)
+    announcement_date = Column(Date)
+    release_date = Column(Date)
     fandom = Column(String)
     season = Column(String)
-    release_date = Column(Date)
+    images = Column(JSONB)
+    product_url = Column(String)

--- a/nendoroid_viewer/backend/requirements.txt
+++ b/nendoroid_viewer/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+sqlalchemy[asyncio]
+asyncpg

--- a/nendoroid_viewer/frontend/README.md
+++ b/nendoroid_viewer/frontend/README.md
@@ -2,6 +2,8 @@
 
 This directory contains a minimal Vue 3 application powered by Vite.
 
+It displays each figure with description, announcement and release dates and images fetched from the backend.
+
 ## Setup
 
 Install dependencies with npm (or yarn) and run the development server:

--- a/nendoroid_viewer/frontend/README.md
+++ b/nendoroid_viewer/frontend/README.md
@@ -1,0 +1,14 @@
+# Nendoroid Viewer Frontend
+
+This directory contains a minimal Vue 3 application powered by Vite.
+
+## Setup
+
+Install dependencies with npm (or yarn) and run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The app proxies API requests to `http://localhost:8000/api`.

--- a/nendoroid_viewer/frontend/package.json
+++ b/nendoroid_viewer/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "nendoroid-viewer",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.3.4",
+    "axios": "^1.4.0"
+  },
+  "devDependencies": {
+    "vite": "^4.3.9",
+    "@vitejs/plugin-vue": "^4.2.3"
+  }
+}

--- a/nendoroid_viewer/frontend/src/App.vue
+++ b/nendoroid_viewer/frontend/src/App.vue
@@ -11,7 +11,14 @@
       <button @click="load">Load</button>
     </div>
     <ul>
-      <li v-for="fig in figures" :key="fig.id">{{ fig.name }} ({{ fig.release_date }})</li>
+      <li v-for="fig in figures" :key="fig.id">
+        <h3>{{ fig.name }}</h3>
+        <p>{{ fig.description }}</p>
+        <small>Announced: {{ fig.announcement_date }} | Release: {{ fig.release_date }}</small>
+        <div class="images">
+          <img v-for="(img, idx) in fig.images" :key="idx" :src="img" alt="" />
+        </div>
+      </li>
     </ul>
   </div>
 </template>

--- a/nendoroid_viewer/frontend/src/App.vue
+++ b/nendoroid_viewer/frontend/src/App.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <h1>Nendoroid Viewer</h1>
+    <div>
+      <label>Fandom:
+        <input v-model="filters.fandom" />
+      </label>
+      <label>Season:
+        <input v-model="filters.season" />
+      </label>
+      <button @click="load">Load</button>
+    </div>
+    <ul>
+      <li v-for="fig in figures" :key="fig.id">{{ fig.name }} ({{ fig.release_date }})</li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import axios from 'axios'
+
+const figures = ref([])
+const filters = ref({ fandom: '', season: '' })
+
+async function load() {
+  const params = {}
+  if (filters.value.fandom) params.fandom = filters.value.fandom
+  if (filters.value.season) params.season = filters.value.season
+  const { data } = await axios.get('/api/nendoroids', { params })
+  figures.value = data
+}
+</script>

--- a/nendoroid_viewer/frontend/src/main.js
+++ b/nendoroid_viewer/frontend/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/nendoroid_viewer/frontend/vite.config.js
+++ b/nendoroid_viewer/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+})

--- a/nendoroid_viewer/scraper/README.md
+++ b/nendoroid_viewer/scraper/README.md
@@ -2,6 +2,8 @@
 
 This directory contains a simple scraper that gathers Nendoroid figure data from the official site.
 
+It saves each figure's name, description, announcement date, release date and images to `nendoroids.json`.
+
 ## Usage
 
 ```bash

--- a/nendoroid_viewer/scraper/README.md
+++ b/nendoroid_viewer/scraper/README.md
@@ -1,0 +1,12 @@
+# Nendoroid Scraper
+
+This directory contains a simple scraper that gathers Nendoroid figure data from the official site.
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+python scraper.py
+```
+
+The output is saved to `nendoroids.json` in this directory.

--- a/nendoroid_viewer/scraper/requirements.txt
+++ b/nendoroid_viewer/scraper/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/nendoroid_viewer/scraper/requirements.txt
+++ b/nendoroid_viewer/scraper/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+python-dateutil

--- a/nendoroid_viewer/scraper/scraper.py
+++ b/nendoroid_viewer/scraper/scraper.py
@@ -1,0 +1,47 @@
+"""Simple scraper for the official Nendoroid website."""
+
+import requests
+from bs4 import BeautifulSoup
+from datetime import datetime
+from pathlib import Path
+import json
+
+BASE_URL = "https://www.goodsmile.info/en/products/category/nendoroid_series/"
+OUTPUT_FILE = Path(__file__).parent / "nendoroids.json"
+
+
+def fetch_nendoroids(page: int = 1) -> list[dict]:
+    """Fetch nendoroids from the given page and return a list of dicts."""
+    url = f"{BASE_URL}?page={page}"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    figures = []
+    for item in soup.select(".list_products > li"):  # CSS selectors depend on site
+        name_el = item.select_one(".p_title")
+        date_el = item.select_one(".p_date")
+        if not name_el:
+            continue
+        name = name_el.text.strip()
+        release_date = date_el.text.strip() if date_el else None
+        figures.append({
+            "name": name,
+            "release_date": release_date,
+        })
+    return figures
+
+
+def scrape_all(pages: int = 1):
+    all_figures = []
+    for p in range(1, pages + 1):
+        all_figures.extend(fetch_nendoroids(p))
+
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+        json.dump(all_figures, f, indent=2, ensure_ascii=False)
+
+    print(f"Saved {len(all_figures)} figures to {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    scrape_all()

--- a/nendoroid_viewer/scraper/scraper.py
+++ b/nendoroid_viewer/scraper/scraper.py
@@ -1,44 +1,71 @@
 """Simple scraper for the official Nendoroid website."""
 
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import urljoin
+
 import requests
 from bs4 import BeautifulSoup
-from datetime import datetime
-from pathlib import Path
-import json
+from dateutil import parser
 
 BASE_URL = "https://www.goodsmile.info/en/products/category/nendoroid_series/"
 OUTPUT_FILE = Path(__file__).parent / "nendoroids.json"
 
 
+def fetch_description(url: str) -> str | None:
+    """Fetch the product page and extract the description."""
+    resp = requests.get(url, headers={"User-Agent": "Mozilla/5.0"}, timeout=10)
+    if resp.status_code != 200:
+        return None
+    soup = BeautifulSoup(resp.text, "html.parser")
+    desc_el = soup.select_one("#description, .description")
+    return desc_el.get_text(" ", strip=True) if desc_el else None
+
+
 def fetch_nendoroids(page: int = 1) -> list[dict]:
     """Fetch nendoroids from the given page and return a list of dicts."""
     url = f"{BASE_URL}?page={page}"
-    resp = requests.get(url, timeout=10)
+    resp = requests.get(url, headers={"User-Agent": "Mozilla/5.0"}, timeout=10)
     resp.raise_for_status()
     soup = BeautifulSoup(resp.text, "html.parser")
 
     figures = []
-    for item in soup.select(".list_products > li"):  # CSS selectors depend on site
-        name_el = item.select_one(".p_title")
-        date_el = item.select_one(".p_date")
-        if not name_el:
+    for item in soup.select(".list_products > li"):
+        link = item.find("a", href=True)
+        if not link:
             continue
-        name = name_el.text.strip()
-        release_date = date_el.text.strip() if date_el else None
-        figures.append({
-            "name": name,
-            "release_date": release_date,
-        })
+        product_url = urljoin(BASE_URL, link["href"])
+        name_el = item.select_one(".p_title")
+        ann_el = item.select_one(".p_announce")
+        rel_el = item.select_one(".p_date")
+        name = name_el.get_text(strip=True) if name_el else None
+        ann_date = parser.parse(ann_el.get_text(strip=True)).date() if ann_el else None
+        rel_date = parser.parse(rel_el.get_text(strip=True)).date() if rel_el else None
+        images = [img["src"] for img in item.select("img") if img.get("src")]
+        description = fetch_description(product_url)
+        figures.append(
+            {
+                "product_id": link["href"].split("/")[-1].split(".")[0],
+                "name": name,
+                "description": description,
+                "announcement_date": ann_date,
+                "release_date": rel_date,
+                "images": images,
+                "product_url": product_url,
+            }
+        )
     return figures
 
 
-def scrape_all(pages: int = 1):
+def scrape_all(pages: int = 1) -> None:
     all_figures = []
     for p in range(1, pages + 1):
         all_figures.extend(fetch_nendoroids(p))
 
     with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
-        json.dump(all_figures, f, indent=2, ensure_ascii=False)
+        json.dump(all_figures, f, indent=2, default=str, ensure_ascii=False)
 
     print(f"Saved {len(all_figures)} figures to {OUTPUT_FILE}")
 


### PR DESCRIPTION
## Summary
- create `nendoroid_viewer` project directory with submodules
- add FastAPI backend with SQLAlchemy models
- include a scraper for the official site using BeautifulSoup
- add Vue 3 frontend powered by Vite

## Testing
- `python3 -m pip install -r nendoroid_viewer/backend/requirements.txt`
- `python3 -m pip install -r nendoroid_viewer/scraper/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_685a6c218df48329949ec43a157cd624