### PR TITLE
Add browser-based transport overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # codex_vibecoding
+
+This project overlays the transport network from one city onto another directly in the browser. It mimics the idea behind *The True Size Of* but for road systems.
+
+## Running
+
+Open `index.html` in a modern browser. You may need to serve the files via a small HTTP server so that network requests are allowed:
+
+```bash
+python -m http.server
+```
+
+Then navigate to `http://localhost:8000` and enter two city names. The base city's roads are drawn in black, and the overlay city is translated in red.
+
+The page uses the Overpass API and Nominatim to fetch data from OpenStreetMap, so an internet connection is required.
+
+## Legacy Python script
+
+The repository still includes `overlay_transport.py`, which performs a similar overlay using Python and OSMnx. Install the dependencies from `requirements.txt` and run the script with two city names:
+
+```bash
+python overlay_transport.py -a "Tokyo, Japan" -b "Moscow, Russia" -o overlay.png
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Overlay Transport Networks</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; }
+  #map { height: calc(100% - 60px); }
+  #controls { padding: 10px; background: #fff; }
+</style>
+</head>
+<body>
+<div id="controls">
+  <label>Overlay City: <input type="text" id="overlayCity" placeholder="Tokyo, Japan"></label>
+  <label>Base City: <input type="text" id="baseCity" placeholder="Moscow, Russia"></label>
+  <button id="loadBtn">Overlay</button>
+</div>
+<div id="map"></div>
+
+<script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+<script src="https://unpkg.com/osmtogeojson@3.0.0/osmtogeojson.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/overlay_transport.py
+++ b/overlay_transport.py
@@ -1,0 +1,40 @@
+import argparse
+import osmnx as ox
+from shapely.affinity import translate
+import matplotlib.pyplot as plt
+
+def overlay_transport(city_a, city_b, network_type='drive', output=None):
+    """Download transport networks for two cities and overlay them."""
+    ox.settings.use_cache=True
+    ox.settings.log_console=False
+    G_a = ox.graph_from_place(city_a, network_type=network_type)
+    G_b = ox.graph_from_place(city_b, network_type=network_type)
+    edges_a = ox.graph_to_gdfs(G_a, nodes=False, edges=True)
+    edges_b = ox.graph_to_gdfs(G_b, nodes=False, edges=True)
+    a_centroid = edges_a.unary_union.centroid
+    b_centroid = edges_b.unary_union.centroid
+    dx = b_centroid.x - a_centroid.x
+    dy = b_centroid.y - a_centroid.y
+    edges_a['geometry'] = edges_a['geometry'].apply(lambda g: translate(g, xoff=dx, yoff=dy))
+    fig, ax = plt.subplots(figsize=(10,10))
+    edges_b.plot(ax=ax, color='black', linewidth=0.5, label=city_b)
+    edges_a.plot(ax=ax, color='red', linewidth=0.5, label=city_a)
+    ax.set_axis_off()
+    ax.legend()
+    if output:
+        plt.savefig(output, bbox_inches='tight')
+    else:
+        plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Overlay transport networks of two cities")
+    parser.add_argument('-a', '--city-a', required=True, help='Transport network to overlay')
+    parser.add_argument('-b', '--city-b', required=True, help='Base city to overlay onto')
+    parser.add_argument('-t', '--type', default='drive', help='Network type (default: drive)')
+    parser.add_argument('-o', '--output', help='Output image file path')
+    args = parser.parse_args()
+    overlay_transport(args.city_a, args.city_b, network_type=args.type, output=args.output)
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+osmnx
+geopandas

--- a/script.js
+++ b/script.js
@@ -1,0 +1,68 @@
+const map = L.map('map').setView([55.751244, 37.618423], 11);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+  attribution: '© OpenStreetMap contributors'
+}).addTo(map);
+
+let overlayLayer;
+let baseLayer;
+
+async function geocode(city) {
+  const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(city)}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Geocoding failed');
+  const data = await res.json();
+  if (!data.length) throw new Error('City not found');
+  const c = data[0];
+  const bbox = c.boundingbox.map(Number);
+  return {lat: parseFloat(c.lat), lon: parseFloat(c.lon), bbox};
+}
+
+async function fetchRoads(bbox) {
+  const query = `[out:json][timeout:25];(way["highway"](${bbox.join(',')}););out body;>;out skel qt;`;
+  const res = await fetch('https://overpass-api.de/api/interpreter', {
+    method: 'POST',
+    body: query
+  });
+  if (!res.ok) throw new Error('Overpass request failed');
+  const data = await res.json();
+  return osmtogeojson(data);
+}
+
+function translateGeoJSON(geojson, dx, dy) {
+  function translateCoords(coords) {
+    for (let i = 0; i < coords.length; i++) {
+      if (Array.isArray(coords[i][0])) {
+        translateCoords(coords[i]);
+      } else {
+        coords[i][0] += dx;
+        coords[i][1] += dy;
+      }
+    }
+  }
+  const copy = JSON.parse(JSON.stringify(geojson));
+  copy.features.forEach(f => translateCoords(f.geometry.coordinates));
+  return copy;
+}
+
+async function overlay() {
+  const overlayCity = document.getElementById('overlayCity').value;
+  const baseCity = document.getElementById('baseCity').value;
+  if (!overlayCity || !baseCity) return alert('Please enter both cities');
+  try {
+    const [overlayInfo, baseInfo] = await Promise.all([geocode(overlayCity), geocode(baseCity)]);
+    const [overlayRoads, baseRoads] = await Promise.all([fetchRoads(overlayInfo.bbox), fetchRoads(baseInfo.bbox)]);
+    const dx = baseInfo.lon - overlayInfo.lon;
+    const dy = baseInfo.lat - overlayInfo.lat;
+    const movedOverlay = translateGeoJSON(overlayRoads, dx, dy);
+    if (overlayLayer) map.removeLayer(overlayLayer);
+    if (baseLayer) map.removeLayer(baseLayer);
+    baseLayer = L.geoJSON(baseRoads, {color:'black', weight:1}).addTo(map);
+    overlayLayer = L.geoJSON(movedOverlay, {color:'red', weight:1}).addTo(map);
+    map.fitBounds(baseLayer.getBounds());
+  } catch (err) {
+    alert(err.message);
+  }
+}
+
+document.getElementById('loadBtn').addEventListener('click', overlay);


### PR DESCRIPTION
## Summary
- add HTML/JS page to overlay roads from one city onto another using Leaflet
- document how to run the new frontend and keep the Python script as a legacy option

## Testing
- `python -m py_compile overlay_transport.py`
- `python -m http.server 8000` then `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68654f56641c832996881d4bf262192a